### PR TITLE
add field ctime (containing most recent metadata change)

### DIFF
--- a/phpscanner.py
+++ b/phpscanner.py
@@ -492,6 +492,7 @@ def is_hacked(filename):
    return {'filename' : filename,
            'score' : total_score,
            'mtime' : os.stat(filename).st_mtime,
+           'ctime' : os.stat(filename).st_ctime,
            'details' : score_details,
            'cleanup' : cleanup_available}
    #print  total_score, filename, '::'.join(score_details).encode('utf-8')


### PR DESCRIPTION
New viruses fake the modification date, showing for example that the file was last modified many years ago. Maybe an attempt to say to the user "hey, do not delete me, I've been here for many years !"
To reproduce it on Linux :

```
$ echo "scanme" > test
$ stat test
[...]
Access: 2015-08-25 08:53:43.581577615 +0200
Modify: 2015-08-25 08:53:43.581577615 +0200
Change: 2015-08-25 08:53:43.581577615 +0200
$ touch -m -d '1 Jan 2006 12:34' test
$ stat test
[...]
Access: 2015-08-25 08:53:43.581577615 +0200
Modify: 2006-01-01 12:34:00.000000000 +0100
Change: 2015-08-25 08:53:57.197573931 +0200
```
