### PR TITLE
add EzPublish cache system to whitelist

### DIFF
--- a/phpscanner.py
+++ b/phpscanner.py
@@ -166,6 +166,7 @@ whitelist = [
   'plugins/gravityforms/form_detail.php',
   'gravityforms/includes/addon/class-gf-results.php',
   'w3-total-cache/inc/functions/multisite.php',
+  '/ezpublish/cache/',
 ]
 
 debug = True


### PR DESCRIPTION
ezPublish uses cache files, and there is too much false-positive on it, so, as this folder cannot be accessed through the web, add it to whitelist.
